### PR TITLE
charger: Hack to set androidboot.mode=charger

### DIFF
--- a/arch/arm/kernel/setup.c
+++ b/arch/arm/kernel/setup.c
@@ -957,6 +957,34 @@ static int __init meminfo_cmp(const void *_a, const void *_b)
 	return cmp < 0 ? -1 : cmp > 0 ? 1 : 0;
 }
 
+/*
+ * HACK: These two functions sets the androidboot.mode=charger based
+ * on the Sony Mobile parameters startup and warmboot.
+ */
+static unsigned long sony_startup;
+
+static int __init sony_param_startup(char *p)
+{
+	if (kstrtoul(p, 16, &sony_startup))
+		return 1;
+	return 0;
+}
+early_param("startup", sony_param_startup);
+
+static int __init sony_param_warmboot(char *p)
+{
+	unsigned long warmboot;
+
+	if (kstrtoul(p, 16, &warmboot))
+		return 1;
+
+	if (!warmboot && (sony_startup & 0x4004))
+		strlcat(boot_command_line, " androidboot.mode=charger",
+			COMMAND_LINE_SIZE);
+	return 0;
+}
+early_param("warmboot", sony_param_warmboot);
+
 void __init setup_arch(char **cmdline_p)
 {
 	struct machine_desc *mdesc;


### PR DESCRIPTION
Based on the parameters startup and warmboot we patch the command line
that init will read to determin if the device was powerd on by a
charger.

Signed-off-by: Bjorn Andersson <bjorn.andersson@sonymobile.com>
Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: If26ffcd5f765c10175bef1126d9e6dc0b70e18e1