### PR TITLE
lib/int_sqrt.c: Revert "optimize square root algorithm"

### DIFF
--- a/lib/int_sqrt.c
+++ b/lib/int_sqrt.c
@@ -1,9 +1,3 @@
-/*
- * Copyright (C) 2013 Davidlohr Bueso <davidlohr.bueso@hp.com>
- *
- *  Based on the shift-and-subtract algorithm for computing integer
- *  square root from Guy L. Steele.
- */
 
 #include <linux/kernel.h>
 #include <linux/export.h>
@@ -16,23 +10,23 @@
  */
 unsigned long int_sqrt(unsigned long x)
 {
-	unsigned long b, m, y = 0;
+	unsigned long op, res, one;
 
-	if (x <= 1)
-		return x;
+	op = x;
+	res = 0;
 
-	m = 1UL << (BITS_PER_LONG - 2);
-	while (m != 0) {
-		b = y + m;
-		y >>= 1;
+	one = 1UL << (BITS_PER_LONG - 2);
+	while (one > op)
+		one >>= 2;
 
-		if (x >= b) {
-			x -= b;
-			y += m;
+	while (one != 0) {
+		if (op >= res + one) {
+			op = op - (res + one);
+			res = res +  2 * one;
 		}
-		m >>= 2;
+		res /= 2;
+		one /= 4;
 	}
-
-	return y;
+	return res;
 }
 EXPORT_SYMBOL(int_sqrt);


### PR DESCRIPTION
 * Restore the original implementation of sqrt

 * After multiple tests around both algorithms and
    variations I made to optimize as much as possible,
    running mostly on a Nios II softcore on an FPGA,
    it becomes clear that the original sources perform
    the best in all situations except sqrt(1) obviously,
    with up to 20% cycles won at same clock and values

 * The reverted commit shares benchmark statistics of
    1,000,000 iterations with the old and new sqrt,
    however one important notion was overlooked:
    The 3 context-switches break the study, it is no
    longer a simple sqrt performance test but involves
    something entirely different that could have lasted 90%
    of the test, hence the enormous branches amount

Reverts commit 31fdc06643b66952107fac478669505c0d8f596a
Change-Id: I97a7528f13b886b4a2145006da06efb986936a05
Signed-off-by: Adrian DC <radian.dc@gmail.com>